### PR TITLE
Update de.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.10.8](https://github.com/iamkun/dayjs/compare/v1.10.7...v1.10.8) (2022-02-28)
+
+
+### Bug Fixes
+
+* set locale pt, pt-br correct weekdays and months ([#1697](https://github.com/iamkun/dayjs/issues/1697)) ([e019301](https://github.com/iamkun/dayjs/commit/e01930171c8235f58a114236f146086428f99569))
+
 ## [1.10.7](https://github.com/iamkun/dayjs/compare/v1.10.6...v1.10.7) (2021-09-10)
 
 

--- a/docs/es-es/README-es-es.md
+++ b/docs/es-es/README-es-es.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+Español (España) | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Русский](../ru/README-ru.md)
+
+<p align="center"><a href="https://day.js.org/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Alternativa rápida y ligera <b>2kB</b> a Moment.js, con la misma API moderna</p>

--- a/docs/ja/README-ja.md
+++ b/docs/ja/README-ja.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+日本語 | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md) | [Русский](../ru/README-ru.md)
+
+<p align="center"><a href="https://day.js.org/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Moment.js と同じ API を備えた <b>2kB</b> の軽量ライブラリ</p>

--- a/docs/ko/README-ko.md
+++ b/docs/ko/README-ko.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+한국어 | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [Español (España)](../es-es/README-es-es.md) | [Русский](../ru/README-ru.md)
+
+<p align="center"><a href="https://day.js.org/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Moment.js와 호환되는 API를 가진 경량 라이브러리 (<b>2kB</b>)</p>

--- a/docs/pt-br/README-pt-br.md
+++ b/docs/pt-br/README-pt-br.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+Português Brasileiro | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md) | [Русский](../ru/README-ru.md)
+
+<p align="center"><a href="https://day.js.org/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Alternativa veloz ao Moment.js, com <b>2kB</b> e a mesma API moderna</p>

--- a/docs/ru/README-ru.md
+++ b/docs/ru/README-ru.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+Русский | [English](../../README.md) | [简体中文](../zh-cn/README.zh-CN.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md)
+
+<p align="center"><a href="https://day.js.org/ru/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Быстрая <b>2kB</b> альтернатива Moment.js с тем же современным API</p>
@@ -27,7 +29,7 @@
 dayjs().startOf('month').add(1, 'day').set('year', 2018).format('YYYY-MM-DD HH:mm:ss');
 ```
 
-* 🕒 Хорошо знакомые API и паттерны Moment.js 
+* 🕒 Хорошо знакомые API и паттерны Moment.js
 * 💪 Неизменная
 * 🔥 Цепная
 * 🌐 Поддержка интернационализации (I18n)

--- a/docs/zh-cn/README.zh-CN.md
+++ b/docs/zh-cn/README.zh-CN.md
@@ -1,4 +1,6 @@
-<p align="center"><a href="#" target="_blank" rel="noopener noreferrer"><img width="550"
+简体中文 | [English](../../README.md) | [日本語](../ja/README-ja.md) | [Português Brasileiro](../pt-br/README-pt-br.md) | [한국어](../ko/README-ko.md) | [Español (España)](../es-es/README-es-es.md) | [Русский](../ru/README-ru.md)
+
+<p align="center"><a href="https://day.js.org/zh-CN/" target="_blank" rel="noopener noreferrer"><img width="550"
                                                                              src="https://user-images.githubusercontent.com/17680888/39081119-3057bbe2-456e-11e8-862c-646133ad4b43.png"
                                                                              alt="Day.js"></a></p>
 <p align="center">Moment.js 的 <b>2kB</b> 轻量化方案，拥有同样强大的 API</p>

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,17 @@ const parseLocale = (preset, object, isLocal) => {
   let l
   if (!preset) return L
   if (typeof preset === 'string') {
-    if (Ls[preset]) {
-      l = preset
+    const presetLower = preset.toLowerCase()
+    if (Ls[presetLower]) {
+      l = presetLower
     }
     if (object) {
-      Ls[preset] = object
-      l = preset
+      Ls[presetLower] = object
+      l = presetLower
+    }
+    const presetSplit = preset.split('-')
+    if (!l && presetSplit.length > 1) {
+      return parseLocale(presetSplit[0])
     }
   } else {
     const { name } = preset

--- a/src/locale/de-at.js
+++ b/src/locale/de-at.js
@@ -1,6 +1,28 @@
 // German (Austria) [de-at]
 import dayjs from 'dayjs'
 
+const texts = {
+  s: 'ein paar Sekunden',
+  m: ['eine Minute', 'einer Minute'],
+  mm: '%d Minuten',
+  h: ['eine Stunde', 'einer Stunde'],
+  hh: '%d Stunden',
+  d: ['ein Tag', 'einem Tag'],
+  dd: ['%d Tage', '%d Tagen'],
+  M: ['ein Monat', 'einem Monat'],
+  MM: ['%d Monate', '%d Monaten'],
+  y: ['ein Jahr', 'einem Jahr'],
+  yy: ['%d Jahre', '%d Jahren']
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key) {
+  let l = texts[key]
+  if (Array.isArray(l)) {
+    l = l[withoutSuffix ? 0 : 1]
+  }
+  return l.replace('%d', number)
+}
+
 const locale = {
   name: 'de-at',
   weekdays: 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
@@ -21,17 +43,17 @@ const locale = {
   relativeTime: {
     future: 'in %s',
     past: 'vor %s',
-    s: 'ein paar Sekunden',
-    m: 'einer Minute',
-    mm: '%d Minuten',
-    h: 'einer Stunde',
-    hh: '%d Stunden',
-    d: 'einem Tag',
-    dd: '%d Tagen',
-    M: 'einem Monat',
-    MM: '%d Monaten',
-    y: 'einem Jahr',
-    yy: '%d Jahren'
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 

--- a/src/locale/de-ch.js
+++ b/src/locale/de-ch.js
@@ -1,15 +1,37 @@
 // German (Switzerland) [de-ch]
 import dayjs from 'dayjs'
 
+const texts = {
+  s: 'ein paar Sekunden',
+  m: ['eine Minute', 'einer Minute'],
+  mm: '%d Minuten',
+  h: ['eine Stunde', 'einer Stunde'],
+  hh: '%d Stunden',
+  d: ['ein Tag', 'einem Tag'],
+  dd: ['%d Tage', '%d Tagen'],
+  M: ['ein Monat', 'einem Monat'],
+  MM: ['%d Monate', '%d Monaten'],
+  y: ['ein Jahr', 'einem Jahr'],
+  yy: ['%d Jahre', '%d Jahren']
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key) {
+  let l = texts[key]
+  if (Array.isArray(l)) {
+    l = l[withoutSuffix ? 0 : 1]
+  }
+  return l.replace('%d', number)
+}
+
 const locale = {
   name: 'de-ch',
   weekdays: 'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
-  months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  weekStart: 1,
   weekdaysShort: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
-  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
-  ordinal: n => n,
+  months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
+  ordinal: n => `${n}.`,
+  weekStart: 1,
   formats: {
     LT: 'HH:mm',
     LTS: 'HH:mm:ss',
@@ -17,10 +39,24 @@ const locale = {
     LL: 'D. MMMM YYYY',
     LLL: 'D. MMMM YYYY HH:mm',
     LLLL: 'dddd, D. MMMM YYYY HH:mm'
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: 'vor %s',
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -29,7 +29,7 @@ const locale = {
   weekdaysShort: 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
   months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  monthsShort: 'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sept_Okt_Nov_Dez'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
   yearStart: 4,

--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -29,7 +29,7 @@ const locale = {
   weekdaysShort: 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
   weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
   months: 'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split('_'),
-  monthsShort: 'Jan_Feb_März_Apr_Mai_Juni_Juli_Aug_Sept_Okt_Nov_Dez'.split('_'),
+  monthsShort: 'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sept._Okt._Nov._Dez.'.split('_'),
   ordinal: n => `${n}.`,
   weekStart: 1,
   yearStart: 4,

--- a/src/locale/gl.js
+++ b/src/locale/gl.js
@@ -9,7 +9,7 @@ const locale = {
   weekdaysShort: 'dom._lun._mar._mér._xov._ven._sáb.'.split('_'),
   monthsShort: 'xan._feb._mar._abr._mai._xuñ._xul._ago._set._out._nov._dec.'.split('_'),
   weekdaysMin: 'do_lu_ma_mé_xo_ve_sá'.split('_'),
-  ordinal: n => n,
+  ordinal: n => `${n}º`,
   formats: {
     LT: 'H:mm',
     LTS: 'H:mm:ss',
@@ -17,6 +17,21 @@ const locale = {
     LL: 'D [de] MMMM [de] YYYY',
     LLL: 'D [de] MMMM [de] YYYY H:mm',
     LLLL: 'dddd, D [de] MMMM [de] YYYY H:mm'
+  },
+  relativeTime: {
+    future: 'en %s',
+    past: 'fai %s',
+    s: 'uns segundos',
+    m: 'un minuto',
+    mm: '%d minutos',
+    h: 'unha hora',
+    hh: '%d horas',
+    d: 'un día',
+    dd: '%d días',
+    M: 'un mes',
+    MM: '%d meses',
+    y: 'un ano',
+    yy: '%d anos'
   }
 }
 

--- a/src/locale/is.js
+++ b/src/locale/is.js
@@ -1,6 +1,45 @@
 // Icelandic [is]
 import dayjs from 'dayjs'
 
+const texts = {
+  s: ['nokkrar sekúndur', 'nokkrar sekúndur', 'nokkrum sekúndum'],
+  m: ['mínúta', 'mínútu', 'mínútu'],
+  mm: ['mínútur', 'mínútur', 'mínútum'],
+  h: ['klukkustund', 'klukkustund', 'klukkustund'],
+  hh: ['klukkustundir', 'klukkustundir', 'klukkustundum'],
+  d: ['dagur', 'dag', 'degi'],
+  dd: ['dagar', 'daga', 'dögum'],
+  M: ['mánuður', 'mánuð', 'mánuði'],
+  MM: ['mánuðir', 'mánuði', 'mánuðum'],
+  y: ['ár', 'ár', 'ári'],
+  yy: ['ár', 'ár', 'árum']
+}
+
+function resolveTemplate(key, number, isFuture, withoutSuffix) {
+  const suffixIndex = isFuture
+    ? 1
+    : 2
+
+  const index = withoutSuffix
+    ? 0
+    : suffixIndex
+
+  const keyShouldBeSingular = key.length === 2 && number % 10 === 1
+
+  const correctedKey = keyShouldBeSingular ? key[0] : key
+  const unitText = texts[correctedKey]
+  const text = unitText[index]
+  return key.length === 1
+    ? text
+    : `%d ${text}`
+}
+
+function relativeTimeFormatter(number, withoutSuffix, key, isFuture) {
+  const template = resolveTemplate(key, number, isFuture, withoutSuffix)
+
+  return template.replace('%d', number)
+}
+
 const locale = {
   name: 'is',
   weekdays: 'sunnudagur_mánudagur_þriðjudagur_miðvikudagur_fimmtudagur_föstudagur_laugardagur'.split('_'),
@@ -17,10 +56,24 @@ const locale = {
     LL: 'D. MMMM YYYY',
     LLL: 'D. MMMM YYYY [kl.] H:mm',
     LLLL: 'dddd, D. MMMM YYYY [kl.] H:mm'
+  },
+  relativeTime: {
+    future: 'eftir %s',
+    past: 'fyrir %s síðan',
+    s: relativeTimeFormatter,
+    m: relativeTimeFormatter,
+    mm: relativeTimeFormatter,
+    h: relativeTimeFormatter,
+    hh: relativeTimeFormatter,
+    d: relativeTimeFormatter,
+    dd: relativeTimeFormatter,
+    M: relativeTimeFormatter,
+    MM: relativeTimeFormatter,
+    y: relativeTimeFormatter,
+    yy: relativeTimeFormatter
   }
 }
 
 dayjs.locale(locale, null, true)
 
 export default locale
-

--- a/src/locale/ku.js
+++ b/src/locale/ku.js
@@ -18,6 +18,7 @@ const locale = {
     LLL: 'D MMMM YYYY HH:mm',
     LLLL: 'dddd, D MMMM YYYY HH:mm'
   },
+  meridiem: hour => (hour < 12 ? 'پ.ن' : 'د.ن'),
   relativeTime: {
     future: 'له‌ %s',
     past: '%s',

--- a/src/locale/pt-br.js
+++ b/src/locale/pt-br.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs'
 
 const locale = {
   name: 'pt-br',
-  weekdays: 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-  weekdaysShort: 'Dom_Seg_Ter_Qua_Qui_Sex_Sáb'.split('_'),
+  weekdays: 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+  weekdaysShort: 'dom_seg_ter_qua_qui_sex_sáb'.split('_'),
   weekdaysMin: 'Do_2ª_3ª_4ª_5ª_6ª_Sá'.split('_'),
-  months: 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-  monthsShort: 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+  months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+  monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
   ordinal: n => `${n}º`,
   formats: {
     LT: 'HH:mm',

--- a/src/locale/pt.js
+++ b/src/locale/pt.js
@@ -3,11 +3,11 @@ import dayjs from 'dayjs'
 
 const locale = {
   name: 'pt',
-  weekdays: 'Domingo_Segunda-feira_Terça-feira_Quarta-feira_Quinta-feira_Sexta-feira_Sábado'.split('_'),
-  weekdaysShort: 'Dom_Seg_Ter_Qua_Qui_Sex_Sab'.split('_'),
+  weekdays: 'domingo_segunda-feira_terça-feira_quarta-feira_quinta-feira_sexta-feira_sábado'.split('_'),
+  weekdaysShort: 'dom_seg_ter_qua_qui_sex_sab'.split('_'),
   weekdaysMin: 'Do_2ª_3ª_4ª_5ª_6ª_Sa'.split('_'),
-  months: 'Janeiro_Fevereiro_Março_Abril_Maio_Junho_Julho_Agosto_Setembro_Outubro_Novembro_Dezembro'.split('_'),
-  monthsShort: 'Jan_Fev_Mar_Abr_Mai_Jun_Jul_Ago_Set_Out_Nov_Dez'.split('_'),
+  months: 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'.split('_'),
+  monthsShort: 'jan_fev_mar_abr_mai_jun_jul_ago_set_out_nov_dez'.split('_'),
   ordinal: n => `${n}º`,
   weekStart: 1,
   yearStart: 4,

--- a/src/locale/rn.js
+++ b/src/locale/rn.js
@@ -1,0 +1,40 @@
+// Kirundi [rn]
+import dayjs from 'dayjs'
+
+const locale = {
+  name: 'rn',
+  weekdays: 'Ku wa Mungu_Ku wa Mbere_Ku wa Kabiri_Ku wa Gatatu_Ku wa Kane_Ku wa Gatanu_Ku wa Gatandatu'.split('_'),
+  weekdaysShort: 'Kngu_Kmbr_Kbri_Ktat_Kkan_Ktan_Kdat'.split('_'),
+  weekdaysMin: 'K7_K1_K2_K3_K4_K5_K6'.split('_'),
+  months: 'Nzero_Ruhuhuma_Ntwarante_Ndamukiza_Rusama_Ruhenshi_Mukakaro_Myandagaro_Nyakanga_Gitugutu_Munyonyo_Kigarama'.split('_'),
+  monthsShort: 'Nzer_Ruhuh_Ntwar_Ndam_Rus_Ruhen_Muk_Myand_Nyak_Git_Muny_Kig'.split('_'),
+  weekStart: 1,
+  ordinal: n => n,
+  relativeTime: {
+    future: 'mu %s',
+    past: '%s',
+    s: 'amasegonda',
+    m: 'Umunota',
+    mm: '%d iminota',
+    h: 'isaha',
+    hh: '%d amasaha',
+    d: 'Umunsi',
+    dd: '%d iminsi',
+    M: 'ukwezi',
+    MM: '%d amezi',
+    y: 'umwaka',
+    yy: '%d imyaka'
+  },
+  formats: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD/MM/YYYY',
+    LL: 'D MMMM YYYY',
+    LLL: 'D MMMM YYYY HH:mm',
+    LLLL: 'dddd, D MMMM YYYY HH:mm'
+  }
+}
+
+dayjs.locale(locale, null, true)
+
+export default locale

--- a/test/locale/de.test.js
+++ b/test/locale/de.test.js
@@ -3,6 +3,8 @@ import moment from 'moment'
 import dayjs from '../../src'
 import relativeTime from '../../src/plugin/relativeTime'
 import '../../src/locale/de'
+import '../../src/locale/de-at'
+import '../../src/locale/de-ch'
 
 dayjs.extend(relativeTime)
 
@@ -39,11 +41,15 @@ it('German locale relative time in past and future with suffix', () => {
     [4, 'y', 'in 4 Jahren'],
     [-4, 'y', 'vor 4 Jahren']
   ]
-  cases.forEach((c) => {
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
-      .toBe(c[2])
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow())
-      .toBe(moment().add(c[0], c[1]).locale('de').fromNow())
+
+  const locales = ['de', 'de-at', 'de-ch']
+  locales.forEach((locale) => {
+    cases.forEach((c) => {
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow())
+        .toBe(c[2])
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow())
+        .toBe(moment().add(c[0], c[1]).locale(locale).fromNow())
+    })
   })
 })
 
@@ -70,10 +76,27 @@ it('German locale relative time in past and future without suffix', () => {
     [4, 'y', '4 Jahre'],
     [-4, 'y', '4 Jahre']
   ]
-  cases.forEach((c) => {
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
-      .toBe(c[2])
-    expect(dayjs().add(c[0], c[1]).locale('de').fromNow(true))
-      .toBe(moment().add(c[0], c[1]).locale('de').fromNow(true))
+
+  const locales = ['de', 'de-at', 'de-ch']
+  locales.forEach((locale) => {
+    cases.forEach((c) => {
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow(true))
+        .toBe(c[2])
+      expect(dayjs().add(c[0], c[1]).locale(locale).fromNow(true))
+        .toBe(moment().add(c[0], c[1]).locale(locale).fromNow(true))
+    })
+  })
+})
+
+it('German locales use region specific names', () => {
+  const locales = [
+    { locale: 'de', expectedFormattedDate: 'Mi., 19. Januar 2022' },
+    { locale: 'de-at', expectedFormattedDate: 'Mi., 19. Jänner 2022' },
+    { locale: 'de-ch', expectedFormattedDate: 'Mi, 19. Januar 2022' }
+  ]
+
+  locales.forEach((locale) => {
+    const dayjsWithLocale = dayjs('2022-01-19').locale(locale.locale)
+    expect(dayjsWithLocale.format('ddd, D. MMMM YYYY')).toEqual(locale.expectedFormattedDate)
   })
 })

--- a/test/locale/is.test.js
+++ b/test/locale/is.test.js
@@ -1,0 +1,115 @@
+import MockDate from 'mockdate'
+import moment from 'moment'
+import dayjs from '../../src'
+import '../../src/locale/is'
+import relativeTime from '../../src/plugin/relativeTime'
+
+dayjs.extend(relativeTime)
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+const expectations = [
+  [1, 's', 'nokkrar sekúndur', 'fyrir nokkrum sekúndum síðan', 'eftir nokkrar sekúndur'],
+  [1, 'm', 'mínúta', 'fyrir mínútu síðan', 'eftir mínútu'],
+  [1, 'h', 'klukkustund', 'fyrir klukkustund síðan', 'eftir klukkustund'],
+  [1, 'd', 'dagur', 'fyrir degi síðan', 'eftir dag'],
+  [1, 'M', 'mánuður', 'fyrir mánuði síðan', 'eftir mánuð'],
+  [1, 'y', 'ár', 'fyrir ári síðan', 'eftir ár'],
+  [2, 'm', '2 mínútur', 'fyrir 2 mínútum síðan', 'eftir 2 mínútur'],
+  [2, 'h', '2 klukkustundir', 'fyrir 2 klukkustundum síðan', 'eftir 2 klukkustundir'],
+  [2, 'd', '2 dagar', 'fyrir 2 dögum síðan', 'eftir 2 daga'],
+  [2, 'M', '2 mánuðir', 'fyrir 2 mánuðum síðan', 'eftir 2 mánuði'],
+  [2, 'y', '2 ár', 'fyrir 2 árum síðan', 'eftir 2 ár'],
+  [21, 'm', '21 mínúta', 'fyrir 21 mínútu síðan', 'eftir 21 mínútu'],
+  [21, 'h', '21 klukkustund', 'fyrir 21 klukkustund síðan', 'eftir 21 klukkustund'],
+  [21, 'd', '21 dagur', 'fyrir 21 degi síðan', 'eftir 21 dag'],
+  [21, 'y', '21 ár', 'fyrir 21 ári síðan', 'eftir 21 ár']
+]
+
+describe('moment compatibility', () => {
+  it('without suffix', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, expectationWithoutSuffix] = expectation
+
+      const momentResult = moment()
+        .add(offset, unit)
+        .locale('is')
+        .fromNow(true)
+
+      expect(expectationWithoutSuffix).toBe(momentResult)
+    })
+  })
+
+  it('past', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, , pastExpectation] = expectation
+
+      const momentResult = moment()
+        .add(-offset, unit)
+        .locale('is')
+        .fromNow()
+
+      expect(pastExpectation).toBe(momentResult)
+    })
+  })
+
+  it('future', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, , , futureExpectation] = expectation
+
+      const momentResult = moment()
+        .add(offset, unit)
+        .locale('is')
+        .fromNow()
+
+      expect(futureExpectation).toBe(momentResult)
+    })
+  })
+})
+
+describe('Icelandic output matches moment output', () => {
+  it('without suffix', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, expectationWithoutSuffix] = expectation
+
+      const result = dayjs()
+        .add(offset, unit)
+        .locale('is')
+        .fromNow(true)
+
+      expect(result).toBe(expectationWithoutSuffix)
+    })
+  })
+
+  it('past', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, , pastExpectation] = expectation
+
+      const result = dayjs()
+        .add(-offset, unit)
+        .locale('is')
+        .fromNow()
+
+      expect(result).toBe(pastExpectation)
+    })
+  })
+
+  it('future', () => {
+    expectations.forEach((expectation) => {
+      const [offset, unit, , , futureExpectation] = expectation
+
+      const result = dayjs()
+        .add(offset, unit)
+        .locale('is')
+        .fromNow()
+
+      expect(result).toBe(futureExpectation)
+    })
+  })
+})

--- a/test/locale/ku.test.js
+++ b/test/locale/ku.test.js
@@ -1,0 +1,20 @@
+import MockDate from 'mockdate'
+import dayjs from '../../src'
+import '../../src/locale/ku'
+
+beforeEach(() => {
+  MockDate.set(new Date())
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
+
+it('Format meridiem correctly', () => {
+  for (let i = 0; i <= 23; i += 1) {
+    const dayjsKu = dayjs()
+      .startOf('day')
+      .add(i, 'hour')
+    expect(dayjsKu.locale('ku').format('h A')).toBe(`${i % 12 || 12} ${i < 12 ? 'پ.ن' : 'د.ن'}`)
+  }
+})

--- a/test/plugin/localizedFormat.test.js
+++ b/test/plugin/localizedFormat.test.js
@@ -96,6 +96,16 @@ it('Uses the localized lowercase formats if defined', () => {
   ['l', 'll', 'lll', 'llll'].forEach(option => expect(znDate.format(option)).toBe(znDate.format(znCn.formats[option])))
 })
 
+it('Uses fallback to xx if xx-yy not available', () => {
+  expect(dayjs('2019-02-01').locale('en-yy').format('MMMM'))
+    .toBe('February')
+})
+
+it('Uses xx-yy if xx-YY is provided', () => {
+  expect(dayjs('2019-02-01').locale('es-US').format('MMMM'))
+    .toBe('febrero')
+})
+
 it('Uses the localized uppercase formats as a base for lowercase formats, if not defined', () => {
   const date = new Date()
   const spanishDate = dayjs(date, { locale: es });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ declare namespace dayjs {
 
   export type OptionType = FormatObject | string | string[]
 
-  export type UnitTypeShort = 'd' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
+  export type UnitTypeShort = 'd' | 'D' | 'M' | 'y' | 'h' | 'm' | 's' | 'ms'
 
   export type UnitTypeLong = 'millisecond' | 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year' | 'date'
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -80,7 +80,7 @@ declare namespace dayjs {
      *
      * Months are zero indexed, so January is month 0.
      *
-     * Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the year.
+     * Accepts numbers from 0 to 11. If the range is exceeded, it will bubble up to the next year.
      * ```
      * dayjs().month(0)// => Dayjs
      * ```
@@ -98,7 +98,7 @@ declare namespace dayjs {
     /**
      * Set the date of the month.
      *
-     * Accepts numbers from 1 to 31. If the range is exceeded, it will bubble up to the months.
+     * Accepts numbers from 1 to 31. If the range is exceeded, it will bubble up to the next months.
      * ```
      * dayjs().date(1)// => Dayjs
      * ```
@@ -118,7 +118,7 @@ declare namespace dayjs {
     /**
      * Set the day of the week.
      *
-     * Accepts numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to other weeks.
+     * Accepts numbers from 0 (Sunday) to 6 (Saturday). If the range is exceeded, it will bubble up to next weeks.
      * ```
      * dayjs().day(0)// => Dayjs
      * ```
@@ -136,7 +136,7 @@ declare namespace dayjs {
     /**
      * Set the hour.
      *
-     * Accepts numbers from 0 to 23. If the range is exceeded, it will bubble up to the day.
+     * Accepts numbers from 0 to 23. If the range is exceeded, it will bubble up to the next day.
      * ```
      * dayjs().hour(12)// => Dayjs
      * ```
@@ -154,7 +154,7 @@ declare namespace dayjs {
     /**
      * Set the minutes.
      *
-     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the hour.
+     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the next hour.
      * ```
      * dayjs().minute(59)// => Dayjs
      * ```
@@ -172,7 +172,7 @@ declare namespace dayjs {
     /**
      * Set the seconds.
      *
-     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the minutes.
+     * Accepts numbers from 0 to 59. If the range is exceeded, it will bubble up to the next minutes.
      * ```
      * dayjs().second(1)// Dayjs
      * ```
@@ -189,7 +189,7 @@ declare namespace dayjs {
     /**
      * Set the milliseconds.
      *
-     * Accepts numbers from 0 to 999. If the range is exceeded, it will bubble up to the seconds.
+     * Accepts numbers from 0 to 999. If the range is exceeded, it will bubble up to the next seconds.
      * ```
      * dayjs().millisecond(1)// => Dayjs
      * ```

--- a/types/plugin/updateLocale.d.ts
+++ b/types/plugin/updateLocale.d.ts
@@ -4,5 +4,5 @@ declare const plugin: PluginFunc
 export = plugin
 
 declare module 'dayjs' {
-  export function updateLocale(localeName: String, customConfig: Object): any
+  export function updateLocale(localeName: string, customConfig: Record<string, unknown>): Record<string, unknown>
 }


### PR DESCRIPTION
This PR adds the abbreviations for German months including a `.` in the end, as in `Januar` -> `Jan.`.

[Duden DE](https://www.duden.de/rechtschreibung/Sept_)